### PR TITLE
Fixed Formatting

### DIFF
--- a/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Set_Up_Tenant.md
+++ b/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Set_Up_Tenant.md
@@ -109,7 +109,7 @@ In your role as Holly Dickson, Adatum's Enterprise Administrator, you have been 
 
 28. Select **Save** when you are done and then close the **Custom themes** pane.
 
-29. Remain logged into LON-DC1 with Microsoft Edge open to the **Microsoft 365 admin center** for the next task.
+29. Remain logged into **LON-CL1** with Microsoft Edge open to the **Microsoft 365 admin center** for the next task.
 
 
 


### PR DESCRIPTION
No mention to LON-DC1 elsewhere in manual. Standard formatting used throughout manual uses bold for VM names.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-